### PR TITLE
feat: changed colors for readability + added new 6 possible colors

### DIFF
--- a/android/app/src/main/java/ch/inf/usi/mindbricks/ui/onboarding/page/OnboardingUserFragment.java
+++ b/android/app/src/main/java/ch/inf/usi/mindbricks/ui/onboarding/page/OnboardingUserFragment.java
@@ -327,6 +327,7 @@ public class OnboardingUserFragment extends Fragment implements OnboardingStepVa
             Chip chip = (Chip) LayoutInflater.from(requireContext())
                     .inflate(R.layout.view_tag_chip, tagChipGroup, false);
             chip.setText(tag.title());
+            chip.setTextColor(requireContext().getColor(R.color.black));
             chip.setChipBackgroundColor(ColorStateList.valueOf(tag.color()));
             chip.setChipIconTint(ColorStateList.valueOf(tag.color()));
             chip.setOnCloseIconClickListener(v -> {

--- a/android/app/src/main/java/ch/inf/usi/mindbricks/ui/settings/SettingsProfileFragment.java
+++ b/android/app/src/main/java/ch/inf/usi/mindbricks/ui/settings/SettingsProfileFragment.java
@@ -233,6 +233,7 @@ public class SettingsProfileFragment extends Fragment {
             Chip chip = (Chip) LayoutInflater.from(requireContext())
                     .inflate(R.layout.view_tag_chip, tagChipGroup, false);
             chip.setText(tag.title());
+            chip.setTextColor(requireContext().getColor(R.color.black));
             chip.setChipBackgroundColor(ColorStateList.valueOf(tag.color()));
             chip.setChipIconTint(ColorStateList.valueOf(tag.color()));
             chip.setOnCloseIconClickListener(v -> {

--- a/android/app/src/main/java/ch/inf/usi/mindbricks/util/Tags.java
+++ b/android/app/src/main/java/ch/inf/usi/mindbricks/util/Tags.java
@@ -12,7 +12,13 @@ public final class Tags {
                 ctx.getColor(R.color.tag_color_yellow),
                 ctx.getColor(R.color.tag_color_green),
                 ctx.getColor(R.color.tag_color_blue),
-                ctx.getColor(R.color.tag_color_purple)
+                ctx.getColor(R.color.tag_color_purple),
+                ctx.getColor(R.color.tag_color_pink),
+                ctx.getColor(R.color.tag_color_indigo),
+                ctx.getColor(R.color.tag_color_cyan),
+                ctx.getColor(R.color.tag_color_teal),
+                ctx.getColor(R.color.tag_color_lime),
+                ctx.getColor(R.color.tag_color_brown)
         };
     }
 }

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,11 +2,17 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="tag_color_red">#F44336</color>
-    <color name="tag_color_orange">#FB8C00</color>
-    <color name="tag_color_yellow">#FBC02D</color>
-    <color name="tag_color_green">#4CAF50</color>
-    <color name="tag_color_blue">#2196F3</color>
-    <color name="tag_color_purple">#9C27B0</color>
+    <color name="tag_color_red">#EF5350</color>
+    <color name="tag_color_orange">#FFA726</color>
+    <color name="tag_color_yellow">#FFEE58</color>
+    <color name="tag_color_green">#66BB6A</color>
+    <color name="tag_color_blue">#64B5F6</color>
+    <color name="tag_color_purple">#BA68C8</color>
+    <color name="tag_color_pink">#EC407A</color>
+    <color name="tag_color_indigo">#5C6BC0</color>
+    <color name="tag_color_cyan">#26C6DA</color>
+    <color name="tag_color_teal">#26A69A</color>
+    <color name="tag_color_lime">#D4E157</color>
+    <color name="tag_color_brown">#A1887F</color>
 
 </resources>


### PR DESCRIPTION
(disclaimer - generated by Copilot. Just for reference)

This pull request updates the tag color palette used throughout the app, improving both the visual appearance and flexibility of tag colors. It also ensures tag text is always rendered in black for better readability. The most important changes are grouped below:

**Tag color palette expansion and improvement:**

* Added seven new tag colors (`pink`, `indigo`, `cyan`, `teal`, `lime`, `brown`) and updated the existing tag color values for a more modern look in `colors.xml` and the palette returned by `Tags.getTagColorPalette`. [[1]](diffhunk://#diff-6f4d882479a7435be84bee9e3dfa6d04ebc9e5c1f8fbc07ae3f35594853340d6L5-R16) [[2]](diffhunk://#diff-b84b4df4b34772c8f28fe3cabdbfd3695eea34fdfec138bd2586704a3b389ed7L15-R21)

**UI consistency and readability:**

* Updated tag rendering in both `OnboardingUserFragment` and `SettingsProfileFragment` to set the tag text color explicitly to black, ensuring consistent readability regardless of the background color. [[1]](diffhunk://#diff-834590c4361ae386355663e0c0af282f709687d96aa4b221aab84de241e235b9R330) [[2]](diffhunk://#diff-0f59a8361a0aaf299dfa97897052af1a74665b45a95dfc68df3123c6b082f051R236)