### PR TITLE
fix(homefragment): now the default selected tag is "No Tag" - fixes bug

### DIFF
--- a/android/app/src/main/java/ch/inf/usi/mindbricks/ui/nav/home/HomeFragment.java
+++ b/android/app/src/main/java/ch/inf/usi/mindbricks/ui/nav/home/HomeFragment.java
@@ -520,15 +520,16 @@ public class HomeFragment extends Fragment {
         PreferencesManager prefs = new PreferencesManager(requireContext());
         List<Tag> tags = prefs.getUserTags();
 
-        // Add special "Create New Tag" option at the beginning
-        tags.add(0, new Tag("+ Create New Tag", getResources().getColor(R.color.analytics_accent_green, null)));
+        // add default tag "No tag" (user doesn't have to create one for everything)
+        tags.add(0, new Tag("No tag", android.graphics.Color.GRAY));
 
-        // NOTE; add default tag "No tag" (user doesn't have to create one for everything)
-        tags.add(new Tag("No tag", android.graphics.Color.GRAY));
+        // Add special "Create New Tag" option (last)
+        tags.add(new Tag("+ Create New Tag", getResources().getColor(R.color.analytics_accent_green, null)));
 
         // setup spinner items - one component for each tag
         TagSpinnerAdapter adapter = new TagSpinnerAdapter(requireContext(), tags);
         tagSpinner.setAdapter(adapter);
+        tagSpinner.setSelection(0, false); // select "No tag" by default
 
         // Handle tag selection
         tagSpinner.setOnItemSelectedListener(new android.widget.AdapterView.OnItemSelectedListener() {


### PR DESCRIPTION
(Disclaimer - Generated using Copilot)

This pull request updates the tag selection spinner in the `HomeFragment` to improve the user experience. The default "No tag" option is now always listed first, and the "+ Create New Tag" option is consistently placed last. Additionally, "No tag" is selected by default when the spinner is displayed.

Tag spinner improvements:

* Changed the order of tag options so that "No tag" appears first and "+ Create New Tag" appears last in the spinner (`HomeFragment.java`).
* Set the spinner to select "No tag" by default when displayed (`HomeFragment.java`).